### PR TITLE
Consider styling the fringe the same color as the rest of the window

### DIFF
--- a/color-theme-tangotango.el
+++ b/color-theme-tangotango.el
@@ -63,7 +63,7 @@
      (cursor ((t (:background "#fce94f" :foreground "#222222"))))
      (highlight ((t (:background "brown4" :foreground nil))))
      (border ((t (:background "#888a85"))))
-     (fringe ((t (:background "grey10"))))
+     (fringe ((t (:background "#2e3434"))))
      (mode-line ((t (:foreground "#bbbbbc" :background "#222222" :box (:line-width 1 :color nil :style released-button)))))
      (mode-line-inactive ((t (:foreground "#bbbbbc" :background "#555753"))))
      (mode-line-buffer-id ((t (:bold t :foreground "orange" :background nil))))

--- a/tangotango-theme.el
+++ b/tangotango-theme.el
@@ -70,7 +70,7 @@
  `(button ((t (:inherit (link)))))
  `(link ((t (:foreground "dodger blue" :underline (:color foreground-color :style line)))))
  `(link-visited ((default (:inherit (link))) (((class color) (background light)) (:foreground "magenta4")) (((class color) (background dark)) (:foreground "violet"))))
- `(fringe ((t (:background "grey10"))))
+ `(fringe ((t (:background "#2e3434"))))
  `(header-line ((default (:inherit (mode-line))) (((type tty)) (:underline (:color foreground-color :style line) :inverse-video nil)) (((class color grayscale) (background light)) (:box nil :foreground "grey20" :background "grey90")) (((class color grayscale) (background dark)) (:box nil :foreground "grey90" :background "grey20")) (((class mono) (background light)) (:underline (:color foreground-color :style line) :box nil :inverse-video nil :foreground "black" :background "white")) (((class mono) (background dark)) (:underline (:color foreground-color :style line) :box nil :inverse-video nil :foreground "white" :background "black"))))
  `(tooltip ((t (:background "lightyellow" :foreground "black" :inherit (quote variable-pitch)))))
  `(mode-line ((t (:box (:line-width 1 :color nil :style released-button) :background "#222222" :foreground "#bbbbbc"))))


### PR DESCRIPTION
I think this produces a cleaner, more attractive look.

Before:

![tango_before](https://user-images.githubusercontent.com/70800/30777834-2e30317a-a0bc-11e7-9ccb-b009a0d7f909.png)

After:

![tango_after](https://user-images.githubusercontent.com/70800/30777836-3359771a-a0bc-11e7-9683-96e351f3e565.png)

What do you think?