### PR TITLE
Remove eval-when-compile

### DIFF
--- a/color-theme-tangotango.el
+++ b/color-theme-tangotango.el
@@ -32,8 +32,7 @@
 ;;; Code:
 
 ;; color theme (requires http://www.emacswiki.org/cgi-bin/wiki?ColorTheme )
-(eval-when-compile
-  (require 'color-theme))
+(require 'color-theme)
 
 (defun color-theme-tangotango ()
   "A color theme based on Tango Palette colors."


### PR DESCRIPTION
This fixes the following byte-compile warning.

```
color-theme-tangotango.el:46:4: Warning: the function ‘color-theme-install’
    might not be defined at runtime.
```