### PR TITLE
Use lighter red for term for better contrast

### DIFF
--- a/tangotango-theme.el
+++ b/tangotango-theme.el
@@ -231,7 +231,7 @@
  `(term-color-cyan ((t (:foreground "light cyan" :background "light cyan"))))
  `(term-color-green ((t (:foreground "#6ac214" :background "#6ac214"))))
  `(term-color-magenta ((t (:foreground "magenta3" :background "magenta3"))))
- `(term-color-red ((t (:foreground "#a40000" :background "#a40000"))))
+ `(term-color-red ((t (:foreground "#ef2929" :background "#ef2929"))))
  `(term-color-white ((t (:foreground "#eeeeec" :background "#eeeeec"))))
  `(term-color-yellow ((t (:foreground "#edd400" :background "#edd400"))))
  ;; regexp metachars


### PR DESCRIPTION
This still only has a color contrast of 3.03,
but before it was 1.56, so definitely an improvement.

This adds the change I applied to the legacy version of the theme to the proper file.
See https://github.com/juba/color-theme-tangotango/commit/4faf8eab5c7c8184a650bdfa8a003cf5010a249c for the previous change.